### PR TITLE
(IRO-1930) Updated break points.

### DIFF
--- a/stories/Breakpoints.stories.tsx
+++ b/stories/Breakpoints.stories.tsx
@@ -1,0 +1,31 @@
+import { FC, useRef } from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { Badge, useBreakpointValue, useDimensions } from '@chakra-ui/react'
+
+export default {
+  title: 'Components/Breakpoints',
+  component: Badge,
+} as ComponentMeta<typeof Badge>
+
+const Demo: FC = () => {
+  const size = useBreakpointValue([
+    'base',
+    'sm',
+    'sm1',
+    'md',
+    'lg',
+    'xl',
+    '2xl',
+  ])
+  const elementRef = useRef(document.body)
+  const bodyDimension = useDimensions(elementRef, true)
+
+  return (
+    <Badge w={'100%'}>
+      {size}:{' '}
+      {bodyDimension?.borderBox.width + bodyDimension?.padding.right + 1}
+    </Badge>
+  )
+}
+
+export const Breakpoints: ComponentStory<FC> = () => <Demo />

--- a/theme/theme.ts
+++ b/theme/theme.ts
@@ -48,6 +48,14 @@ const IronFishTheme: DeepPartial<ChakraTheme> = {
       },
     }),
   },
+  breakpoints: {
+    sm: '30rem', //480px
+    sm1: '36rem', //576px
+    md: '48rem', //768px
+    lg: '64rem', //1024px
+    xl: '75rem', //1200px
+    '2xl': '90rem', //1440px
+  },
 }
 
 export default IronFishTheme


### PR DESCRIPTION
Found only `sm1: '36rem', //576px` was mentioned in one of PRs, other break points taken from Figma design.
Original breakpoints
```
const breakpoints = {
  sm: '30em', //480px
  md: '48em', //768px
  lg: '62em', //992px
  xl: '80em', //1280px
  '2xl': '96em', //1536px
}
```