### PR TITLE
Make theme extensible

### DIFF
--- a/components/IronFishUIProvider.tsx
+++ b/components/IronFishUIProvider.tsx
@@ -12,15 +12,15 @@ import { css, Global } from '@emotion/react'
 
 type IronFishProps = {
   initialColorMode?: ConfigColorMode
-  theme: DeepPartial<ChakraTheme>
+  theme?: DeepPartial<ChakraTheme>
 }
 
 const IronFishUIProvider: FC<IronFishProps> = ({
   initialColorMode = 'light',
   children,
-  theme: rawTheme,
+  theme: rawTheme = {},
 }) => {
-  const theme = extendTheme({ ...rawTheme, ...IronFishTheme })
+  const theme = extendTheme({ ...IronFishTheme, ...rawTheme })
   return (
     <>
       <ChakraProvider theme={{ ...theme, initialColorMode: initialColorMode }}>

--- a/components/IronFishUIProvider.tsx
+++ b/components/IronFishUIProvider.tsx
@@ -1,19 +1,26 @@
 import type { FC } from 'react'
 
-import { ChakraProvider, ConfigColorMode, extendTheme } from '@chakra-ui/react'
+import {
+  DeepPartial,
+  ChakraTheme,
+  ChakraProvider,
+  ConfigColorMode,
+  extendTheme,
+} from '@chakra-ui/react'
 import IronFishTheme from 'theme/theme'
 import { css, Global } from '@emotion/react'
 
-const theme = extendTheme(IronFishTheme)
-
 type IronFishProps = {
   initialColorMode?: ConfigColorMode
+  theme: DeepPartial<ChakraTheme>
 }
 
 const IronFishUIProvider: FC<IronFishProps> = ({
   initialColorMode = 'light',
   children,
+  theme: rawTheme,
 }) => {
+  const theme = extendTheme({ ...rawTheme, ...IronFishTheme })
   return (
     <>
       <ChakraProvider theme={{ ...theme, initialColorMode: initialColorMode }}>

--- a/theme/theme.ts
+++ b/theme/theme.ts
@@ -9,7 +9,7 @@ const typeface: object = {
   letterSpacing: '0',
 }
 
-const IronFishTheme: DeepPartial<ChakraTheme> = {
+export const IronFishTheme: DeepPartial<ChakraTheme> = {
   components: ThemedComponents,
   styles: {
     global: props => ({


### PR DESCRIPTION
I ran into this while working on the Wallet app, as it uses different breakpoints than we're using in `ui-kit` / `block-explorer-v2` defaults.