### PR TITLE
(IRO-2336) Align row content with header.

### DIFF
--- a/stories/Table.stories.tsx
+++ b/stories/Table.stories.tsx
@@ -1,8 +1,9 @@
 import { FC, useState, useEffect } from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
-import { Box, Flex } from '@chakra-ui/react'
+import { Box, Flex, Link, chakra } from '@chakra-ui/react'
 import { CommonTable } from 'components'
 import { NAMED_COLORS } from 'theme/constants'
+import Caret from 'svgx/icon-caret'
 
 export default {
   title: 'Components/CommonTable',
@@ -94,6 +95,31 @@ const COLUMNS: ColumnProps<BlockType>[] = [
     key: 'block-timestamp',
     label: 'Timestamp',
     render: block => block.timestamp,
+  },
+  {
+    key: 'actions',
+    label: '',
+    WrapperProps: {
+      display: 'flex',
+    },
+    ItemProps: {
+      justifyContent: 'flex-end',
+    },
+    render: () => (
+      <Link
+        sx={{
+          color: NAMED_COLORS.LIGHT_BLUE,
+          _hover: {
+            color: NAMED_COLORS.LIGHT_BLUE,
+          },
+        }}
+      >
+        <Flex>
+          <chakra.h5 mr="0.3125rem">View Details</chakra.h5>
+          <Caret />
+        </Flex>
+      </Link>
+    ),
   },
 ]
 

--- a/svgx/icon-caret.tsx
+++ b/svgx/icon-caret.tsx
@@ -1,0 +1,19 @@
+import { Icon, IconProps } from '@chakra-ui/react'
+
+export const Caret = (props: IconProps) => (
+  <Icon
+    width="20px"
+    height="22px"
+    fill="none"
+    viewBox="0 0 20 22"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M7.15825 7.1187L10.9749 11L7.15825 14.8812L8.33325 16.0735L13.3333 11L8.33325 5.92642L7.15825 7.1187Z"
+      fill="currentColor"
+    />
+  </Icon>
+)
+
+export default Caret

--- a/theme/components/Table.ts
+++ b/theme/components/Table.ts
@@ -29,9 +29,13 @@ const Table: ComponentStyleConfig = {
         fontWeight: '400',
         fontFamily: FONTS.FAVORIT,
         letterSpacing: '0.1em',
-        paddingTop: '0.5rem',
+        paddingTop: '0.125rem',
         paddingBottom: '0',
+        paddingLeft: '1rem',
         borderBottom: 'none',
+        _first: {
+          paddingLeft: '2rem',
+        },
       },
     },
     td: {
@@ -69,6 +73,9 @@ const Table: ComponentStyleConfig = {
       thead: {
         th: {
           p: '0 0 0.9375rem',
+          _first: {
+            paddingLeft: '0',
+          },
         },
       },
       tbody: {


### PR DESCRIPTION
Also added changes from [IRO-2437](https://linear.app/ironfish/issue/IRO-2437/universal-change-padding-above-column-headers-reduce-by-6px)