### PR TITLE
Broken link to Chakra-ui documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ where all available component can be tested and configured.
 
 ## Learn More
 
-- [Chakra-ui documentation](https://chakra-ui.com/guides/first-steps).
+- [Chakra-ui documentation](https://chakra-ui.com/getting-started).
 - [Storybook documentation](https://storybook.js.org/docs/react/get-started/introduction).
 
 


### PR DESCRIPTION
The link https://chakra-ui.com/guides/first-steps is deprecated and we getting an error 404. it should be replaced to https://chakra-ui.com/getting-started