### PR TITLE
Fix options change leads to error.

### DIFF
--- a/components/SelectField.tsx
+++ b/components/SelectField.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect, ReactNode, Element } from 'react'
+import { FC, useState, useEffect, ReactNode } from 'react'
 
 import {
   Box,

--- a/components/SelectField.tsx
+++ b/components/SelectField.tsx
@@ -134,7 +134,7 @@ const SelectField: FC<SelectFieldProps> = ({
                 }
               }}
             >
-              {RenderOption(option)}
+              {<RenderOption {...option} />}
             </Box>
           ))}
         </PopoverBody>

--- a/components/SelectField.tsx
+++ b/components/SelectField.tsx
@@ -64,7 +64,7 @@ const SelectField: FC<SelectFieldProps> = ({
   label,
   value = null,
   options = [],
-  renderOption = Option,
+  renderOption: RenderOption = Option,
   renderSelected = SelectedOption,
   onSelectOption = () => void 0,
   ...props
@@ -134,7 +134,7 @@ const SelectField: FC<SelectFieldProps> = ({
                 }
               }}
             >
-              {renderOption(option)}
+              {<RenderOption {...option} />}
             </Box>
           ))}
         </PopoverBody>

--- a/components/SelectField.tsx
+++ b/components/SelectField.tsx
@@ -55,7 +55,7 @@ interface SelectFieldProps extends FlexProps {
   value?: OptionType
   options?: OptionType[]
   size?: string
-  renderOption?: (option: OptionType) => Element
+  renderOption?: (option: OptionType) => ReactNode
   renderSelected?: (option: OptionType) => ReactNode
   onSelectOption?: (option: OptionType) => void
 }
@@ -64,7 +64,7 @@ const SelectField: FC<SelectFieldProps> = ({
   label,
   value = null,
   options = [],
-  renderOption: RenderOption = Option,
+  renderOption = option => <Option {...option} />,
   renderSelected = SelectedOption,
   onSelectOption = () => void 0,
   ...props
@@ -134,7 +134,7 @@ const SelectField: FC<SelectFieldProps> = ({
                 }
               }}
             >
-              {<RenderOption {...option} />}
+              {renderOption(option)}
             </Box>
           ))}
         </PopoverBody>

--- a/components/SelectField.tsx
+++ b/components/SelectField.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect, ReactNode } from 'react'
+import { FC, useState, useEffect, ReactNode, Element } from 'react'
 
 import {
   Box,
@@ -55,7 +55,7 @@ interface SelectFieldProps extends FlexProps {
   value?: OptionType
   options?: OptionType[]
   size?: string
-  renderOption?: (option: OptionType) => ReactNode
+  renderOption?: (option: OptionType) => Element
   renderSelected?: (option: OptionType) => ReactNode
   onSelectOption?: (option: OptionType) => void
 }
@@ -134,7 +134,7 @@ const SelectField: FC<SelectFieldProps> = ({
                 }
               }}
             >
-              {<RenderOption {...option} />}
+              {RenderOption(option)}
             </Box>
           ))}
         </PopoverBody>

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,7 +1,7 @@
 import { FC, useState, useEffect } from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 import SelectField from 'components/SelectField'
-import { Box, Stack } from '@chakra-ui/react'
+import { Box, Stack, VStack } from '@chakra-ui/react'
 
 export default {
   title: 'Components/Select',
@@ -120,11 +120,28 @@ export const DelayedOptions: ComponentStory<FC> = () => {
   }, [])
 
   return (
-    <Box>
-      <Box>
-        <h4>With default options render</h4>
+    <VStack spacing="2rem" alignItems="start" w="100%">
+      <Box w="50%">
+        <Box>
+          <h4>With default options render</h4>
+        </Box>
+        <SelectField label="Select Label" options={options} />
       </Box>
-      <SelectField label="Select Label" w="50%" options={options} />
-    </Box>
+      <Box w="50%">
+        <Box>
+          <h4>With custom options render</h4>
+        </Box>
+        <SelectField
+          renderOption={option => (
+            <Box px="1.5rem" h="3rem" textAlign="center" pt={2}>
+              <b>{option.label}</b>&nbsp;&nbsp;
+              <small style={{ color: 'red' }}>{option.helperText}</small>
+            </Box>
+          )}
+          label="Select Label"
+          options={options}
+        />
+      </Box>
+    </VStack>
   )
 }

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState, useEffect } from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 import SelectField from 'components/SelectField'
 import { Box, Stack } from '@chakra-ui/react'
@@ -91,3 +91,40 @@ export const BasicExample: ComponentStory<FC> = () => (
     />
   </Stack>
 )
+
+export const DelayedOptions: ComponentStory<FC> = () => {
+  const [options, setOptions] = useState([])
+
+  useEffect(() => {
+    setTimeout(
+      () =>
+        setOptions([
+          {
+            label: 'Test',
+            helperText: 'This is 1 option',
+            value: 'option1',
+          },
+          {
+            label: 'Test',
+            helperText: 'This is 2 option',
+            value: 'option2',
+          },
+          {
+            label: 'Test',
+            helperText: 'This is 3 option',
+            value: 'option3',
+          },
+        ]),
+      3000
+    )
+  }, [])
+
+  return (
+    <Box>
+      <Box>
+        <h4>With default options render</h4>
+      </Box>
+      <SelectField label="Select Label" w="50%" options={options} />
+    </Box>
+  )
+}


### PR DESCRIPTION
The problem:
* When you set options to empty array and then change it to not empty array the following error appears `Error: Rendered more hooks than during the previous render.`

Solution: use renderOption in a component style