### PR TITLE
Added possibility to limit dropdown height, pass props to popover elements.

### DIFF
--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -16,7 +16,10 @@ import {
   InputProps as IProps,
   Popover,
   PopoverBody,
+  PopoverBodyProps,
   PopoverContent,
+  PopoverContentProps,
+  PopoverProps,
   PopoverTrigger,
   useDisclosure,
   useMultiStyleConfig,
@@ -50,6 +53,12 @@ interface AutocompleteProps extends FlexProps {
   onSelectOption?: (option: OptionType) => void
   isClearable?: boolean
   onClear?: () => void
+  maxMenuHeight?: number
+  popoverProps?: {
+    popover: PopoverProps
+    popoverContent: PopoverContentProps
+    popoverBody: PopoverBodyProps
+  }
 }
 
 const Autocomplete: FC<AutocompleteProps> = ({
@@ -65,6 +74,8 @@ const Autocomplete: FC<AutocompleteProps> = ({
   filterOption = defaultOptionsFilter,
   isClearable,
   onClear = () => void 0,
+  maxMenuHeight,
+  popoverProps,
   ...props
 }) => {
   const [val, setVal] = useState<OptionType | null>(value)
@@ -108,6 +119,7 @@ const Autocomplete: FC<AutocompleteProps> = ({
       initialFocusRef={inputRef as RefObject<HTMLInputElement>}
       offset={[0, 0]}
       placement="bottom"
+      {...popoverProps?.popover}
     >
       <PopoverTrigger>
         <Flex
@@ -176,14 +188,27 @@ const Autocomplete: FC<AutocompleteProps> = ({
       </PopoverTrigger>
       <PopoverContent
         w="100%"
+        {...popoverProps?.popoverContent}
         sx={{
           ...styles?.popover,
           borderBottomRadius: isToTop ? 0 : '0.25rem',
           borderTopRadius: isToTop ? '0.25rem' : 0,
+          ...popoverProps?.popoverContent.sx,
         }}
         ref={popoverRef as RefObject<HTMLDivElement>}
       >
-        <PopoverBody w="100%">
+        <PopoverBody
+          w="100%"
+          {...popoverProps?.popoverBody}
+          sx={{
+            ...(maxMenuHeight && {
+              maxHeight: `${maxMenuHeight}px`,
+              overflowY: 'scroll',
+              scrollSnapType: 'y mandatory',
+            }),
+            ...popoverProps?.popoverBody.sx,
+          }}
+        >
           {optionsToDisplay.length > 0 ? (
             optionsToDisplay.map(option => (
               <Box
@@ -197,7 +222,12 @@ const Autocomplete: FC<AutocompleteProps> = ({
                   'option-wrapper',
                   val === option ? 'selected' : ''
                 )}
-                sx={styles?.optionWrapper}
+                sx={{
+                  ...styles?.optionWrapper,
+                  ...(maxMenuHeight && {
+                    scrollSnapAlign: 'start',
+                  }),
+                }}
                 onClick={() => {
                   if (val !== option) {
                     setVal(option)

--- a/components/SelectField.tsx
+++ b/components/SelectField.tsx
@@ -6,7 +6,10 @@ import {
   FlexProps,
   Popover,
   PopoverBody,
+  PopoverBodyProps,
   PopoverContent,
+  PopoverContentProps,
+  PopoverProps,
   PopoverTrigger,
   useDisclosure,
   useMultiStyleConfig,
@@ -93,6 +96,12 @@ interface SelectFieldProps extends FlexProps {
   onSelectOption?: (option: OptionType) => void
   isClearable?: boolean
   onClear?: () => void
+  maxMenuHeight?: number
+  popoverProps?: {
+    popover: PopoverProps
+    popoverContent: PopoverContentProps
+    popoverBody: PopoverBodyProps
+  }
 }
 
 const SelectField: FC<SelectFieldProps> = ({
@@ -105,6 +114,8 @@ const SelectField: FC<SelectFieldProps> = ({
   onSelectOption = () => void 0,
   isClearable,
   onClear = () => void 0,
+  maxMenuHeight,
+  popoverProps,
   ...props
 }) => {
   const [val, setVal] = useState<OptionType | null>(null)
@@ -126,6 +137,7 @@ const SelectField: FC<SelectFieldProps> = ({
       onClose={onClose}
       offset={[0, 0]}
       placement={props.size !== 'compact' ? 'bottom' : 'bottom-end'}
+      {...popoverProps?.popover}
     >
       <PopoverTrigger>
         <Flex
@@ -174,14 +186,27 @@ const SelectField: FC<SelectFieldProps> = ({
       </PopoverTrigger>
       <PopoverContent
         w="100%"
+        {...popoverProps?.popoverContent}
         sx={{
           ...styles?.popover,
           borderBottomRadius: isToTop ? 0 : '0.25rem',
           borderTopRadius: isToTop ? '0.25rem' : 0,
+          ...popoverProps?.popoverContent.sx,
         }}
         ref={containerRef as RefObject<HTMLDivElement>}
       >
-        <PopoverBody w="100%">
+        <PopoverBody
+          w="100%"
+          {...popoverProps?.popoverBody}
+          sx={{
+            ...(maxMenuHeight && {
+              maxHeight: `${maxMenuHeight}px`,
+              overflowY: 'scroll',
+              scrollSnapType: 'y mandatory',
+            }),
+            ...popoverProps?.popoverBody.sx,
+          }}
+        >
           {options.map(option => (
             <Box
               w="100%"
@@ -193,7 +218,12 @@ const SelectField: FC<SelectFieldProps> = ({
               className={bem('option-wrapper', {
                 selected: val === option,
               })}
-              sx={styles?.optionWrapper}
+              sx={{
+                ...styles?.optionWrapper,
+                ...(maxMenuHeight && {
+                  scrollSnapAlign: 'start',
+                }),
+              }}
               onClick={() => {
                 if (val !== option) {
                   setVal(option)

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -214,3 +214,16 @@ export const ClearableExample: ComponentStory<FC> = () => (
     />
   </Stack>
 )
+
+export const MaxMenuHeightExample: ComponentStory<FC> = () => (
+  <SelectField
+    label="Select Label"
+    w="50%"
+    maxMenuHeight={130}
+    options={[...new Array(20)].map((item, index) => ({
+      label: `Test${index}`,
+      helperText: `This is ${index} option`,
+      value: `option ${index}`,
+    }))}
+  />
+)

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -219,7 +219,7 @@ export const MaxMenuHeightExample: ComponentStory<FC> = () => (
   <SelectField
     label="Select Label"
     w="50%"
-    maxMenuHeight={130}
+    maxMenuHeight={325}
     options={[...new Array(20)].map((item, index) => ({
       label: `Test${index}`,
       helperText: `This is ${index} option`,


### PR DESCRIPTION
Additional `popoverProps` is no required, added as it could be used.

[Demo](https://ui-kit-git-feature-ifl-925-ironfish.vercel.app/?path=/story/components-select--max-menu-height-example)